### PR TITLE
Lowercase single word/letter.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (str) {
 	str = str.trim();
 
 	if (str.length === 1 || !(/[_.\- ]+/).test(str) ) {
-		return str;
+		return str.toLowerCase();
 	}
 
 	return str

--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@ module.exports = function (str) {
 	str = str.trim();
 
 	if (str.length === 1 || !(/[_.\- ]+/).test(str) ) {
-		return str.toLowerCase();
+		if (str[0] === str[0].toLowerCase() && str.slice(1) !== str.slice(1).toLowerCase()){
+			return str;
+		} else {
+			return str.toLowerCase();
+		}
 	}
 
 	return str

--- a/test.js
+++ b/test.js
@@ -24,4 +24,7 @@ test('camelCase', function (t) {
 	t.assert(camelCase(' - ') === '-');
 	t.assert(camelCase('fooBar') === 'fooBar');
 	t.assert(camelCase('fooBar-baz') === 'foobarBaz');
+	t.assert(camelCase('F') === 'f');
+	t.assert(camelCase('Foo') === 'foo');
+	t.assert(camelCase('FOO') === 'foo');
 });


### PR DESCRIPTION
Single word/letter should also be _lowercased_.

```js
var camelCase = require('camelcase');

camelCase('K');
//=> k

camelCase('Found');
//=> found

camelCase('Not Found');
//=> notFound
```