### PR TITLE
added multi-arg support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
-module.exports = function (str) {
-	str = str.trim();
+module.exports = function () {
+	var str = [].map.call(arguments, function (str) {
+		return str.trim();
+	}).join('-');
 
 	if (str.length === 1 || !(/[_.\- ]+/).test(str) ) {
 		if (str[0] === str[0].toLowerCase() && str.slice(1) !== str.slice(1).toLowerCase()) {

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,12 @@ console.log(process.argv[3]);
 //=> --foo-bar
 camelCase(process.argv[3]);
 //=> fooBar
+
+camelCase('foo', 'bar');
+//=> fooBar
+
+camelCase('__foo__', '--bar');
+//=> fooBar
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -27,4 +27,7 @@ test('camelCase', function (t) {
 	t.assert(camelCase('F') === 'f');
 	t.assert(camelCase('Foo') === 'foo');
 	t.assert(camelCase('FOO') === 'foo');
+	t.assert(camelCase('foo', 'bar') === 'fooBar');
+	t.assert(camelCase('foo', '-bar') === 'fooBar');
+	t.assert(camelCase('foo', '-bar', 'baz') === 'fooBarBaz');
 });


### PR DESCRIPTION
I don't want to have to join multiple strings together in my app to camel-case them.

Let there be multiple arguments!

```javascript
var foo = camelCase('bar', 'baz', '--qux', 'qix__'); // barBazQuxQix
```