### PR TITLE
provide constructor-case alternate

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
-module.exports = function () {
+camelCase.constructor = constructor;
+module.exports = camelCase;
+
+function camelCase() {
 	var str = [].map.call(arguments, function (str) {
 		return str.trim();
 	}).filter(function (str) {
@@ -24,4 +27,12 @@ module.exports = function () {
 	.replace(/[_.\- ]+(\w|$)/g, function (m, p1) {
 		return p1.toUpperCase();
 	});
-};
+}
+
+function constructor() {
+	var str = camelCase.apply(null, arguments);
+	if (str.length) {
+		str = str[0].toUpperCase() + str.substring(1);
+	}
+	return str;
+}

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import fn from './';
+import fn, {constructor as ct} from './';
 
 test('camelCase', t => {
 	t.is(fn('foo'), 'foo');
@@ -26,10 +26,15 @@ test('camelCase', t => {
 	t.is(fn('F'), 'f');
 	t.is(fn('Foo'), 'foo');
 	t.is(fn('FOO'), 'foo');
+	t.is(ct('FOO'), 'Foo');
 	t.is(fn('foo', 'bar'), 'fooBar');
+	t.is(ct('foo', 'bar'), 'FooBar');
 	t.is(fn('foo', '-bar'), 'fooBar');
+	t.is(ct('foo', '-bar'), 'FooBar');
 	t.is(fn('foo', '-bar', 'baz'), 'fooBarBaz');
+	t.is(ct('foo', '-bar', 'baz'), 'FooBarBaz');
 	t.is(fn('', ''), '');
+	t.is(ct('', ''), '');
 	t.is(fn('--'), '');
 	t.is(fn(''), '');
 	t.is(fn('--__--_--_'), '');


### PR DESCRIPTION
exposes `camelCase.constructor(...)`, which behaves identically except it capitalizes the first letter as well.

useful for determining constructor names