### PR TITLE
Close #8 PR:  `FooBar` becomes correctly `fooBar`

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,11 +15,15 @@ module.exports = function () {
 	}
 
 	if (!(/[_.\- ]+/).test(str)) {
-		if (str[0] === str[0].toLowerCase() && str.slice(1) !== str.slice(1).toLowerCase()) {
-			return str;
+		if (str === str.toUpperCase()) {
+			return str.toLowerCase();
 		}
 
-		return str.toLowerCase();
+		if (str[0] !== str[0].toLowerCase()) {
+			return str[0].toLowerCase() + str.slice(1);
+		}
+
+		return str;
 	}
 
 	return str

--- a/test.js
+++ b/test.js
@@ -24,6 +24,7 @@ test('camelCase', t => {
 	t.is(fn('fooBar'), 'fooBar');
 	t.is(fn('fooBar-baz'), 'foobarBaz');
 	t.is(fn('F'), 'F');
+	t.is(fn('FooBar'), 'fooBar');
 	t.is(fn('Foo'), 'foo');
 	t.is(fn('FOO'), 'foo');
 	t.is(fn('foo', 'bar'), 'fooBar');


### PR DESCRIPTION
Close #8