### PR TITLE
return lowercase if string is length 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function () {
 	}
 
 	if (str.length === 1) {
-		return str;
+		return str.toLowerCase();
 	}
 
 	if (!(/[_.\- ]+/).test(str)) {

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ test('camelCase', t => {
 	t.is(fn('foìBar-baz'), 'foìBarBaz');
 	t.is(fn('fooBarBaz-bazzy'), 'fooBarBazBazzy');
 	t.is(fn('FBBazzy'), 'fBBazzy');
-	t.is(fn('F'), 'F');
+	t.is(fn('F'), 'f');
 	t.is(fn('FBBÈzzy'), 'fBBÈzzy');
 	t.is(fn('FooBar'), 'fooBar');
 	t.is(fn('Foo'), 'foo');


### PR DESCRIPTION
I'm assuming the assertion `t.is(fn('F'), 'F');` was just an oversight. I keep scratching my head, trying to think of a valid reason for this but, nope.