### PR TITLE
Add babel + "browser" package.json field for webpack/browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+browser.js

--- a/package.json
+++ b/package.json
@@ -13,11 +13,15 @@
     "node": ">=4"
   },
   "scripts": {
+    "babel": "babel --presets es2015 index.js -o browser.js",
+    "prepublish": "npm run babel",
     "test": "xo && ava"
   },
   "files": [
+    "browser.js",
     "index.js"
   ],
+  "browser": "browser.js",
   "keywords": [
     "camelcase",
     "camel-case",
@@ -34,6 +38,8 @@
   ],
   "devDependencies": {
     "ava": "*",
+    "babel-cli": "^6.18.0",
+    "babel-preset-es2015": "^6.18.0",
     "xo": "*"
   },
   "xo": {


### PR DESCRIPTION
Add babel prepublish script, add compiled browser.js to package.json "browser" and "files" for better webpack/browserify compat.

Related issue: #19