### PR TITLE
handle list(s) of strings as parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,14 +29,29 @@ function preserveCamelCase(str) {
 	return str;
 }
 
+function flattenArray(arr) {
+	if (Array.isArray(arr)) {
+		return arr
+			.reduce((acc, x) => acc.concat(flattenArray(x)), []);
+	} else {
+		return arr;
+	};
+};
+
 module.exports = function (str) {
+	var arr;
 	if (arguments.length > 1) {
-		str = Array.from(arguments)
-			.map(x => x.trim())
-			.filter(x => x.length)
-			.join('-');
+		arr = flattenArray(Array.from(arguments));
+	} else if (Array.isArray(str)) {
+		arr = flattenArray(str);
 	} else {
 		str = str.trim();
+	}
+	
+	if (!arr) {
+		str = src.map(x => x.trim())
+			.filter(x => x.length)
+			.join('-');
 	}
 
 	if (str.length === 0) {


### PR DESCRIPTION
I think it would be reasonable for this function to accept a list of strings, so I've added support for the following cases
1. the function is called with a single array as its sole parameter
2. ... with many parameters, some, all, or none of which may be arrays
In the case of raggeds, `flattenArray` produces a 1D array by doing an inorder traversal.