### PR TITLE
Update source code to use casex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,71 +1,14 @@
 'use strict';
 
-const preserveCamelCase = input => {
-	let isLastCharLower = false;
-	let isLastCharUpper = false;
-	let isLastLastCharUpper = false;
-
-	for (let i = 0; i < input.length; i++) {
-		const c = input[i];
-
-		if (isLastCharLower && /[a-zA-Z]/.test(c) && c.toUpperCase() === c) {
-			input = input.slice(0, i) + '-' + input.slice(i);
-			isLastCharLower = false;
-			isLastLastCharUpper = isLastCharUpper;
-			isLastCharUpper = true;
-			i++;
-		} else if (isLastCharUpper && isLastLastCharUpper && /[a-zA-Z]/.test(c) && c.toLowerCase() === c) {
-			input = input.slice(0, i - 1) + '-' + input.slice(i - 1);
-			isLastLastCharUpper = isLastCharUpper;
-			isLastCharUpper = false;
-			isLastCharLower = true;
-		} else {
-			isLastCharLower = c.toLowerCase() === c;
-			isLastLastCharUpper = isLastCharUpper;
-			isLastCharUpper = c.toUpperCase() === c;
-		}
-	}
-
-	return input;
-};
+const casex = require('casex');
 
 module.exports = (input, options) => {
-	options = Object.assign({
-		pascalCase: false
-	}, options);
+	input = Array.isArray(input) ? input.join('-') : input;
 
-	const postProcess = x => options.pascalCase ? x.charAt(0).toUpperCase() + x.slice(1) : x;
+	const pattern = (options || {}).pascalCase ? 'CaSe' : 'caSe';
+	const str = input
+		.replace(/[A-Z][a-z]/g, value => `-${value}`)
+		.replace(/[A-Z]+/g, value => `-${value}`);
 
-	if (Array.isArray(input)) {
-		input = input.map(x => x.trim())
-			.filter(x => x.length)
-			.join('-');
-	} else {
-		input = input.trim();
-	}
-
-	if (input.length === 0) {
-		return '';
-	}
-
-	if (input.length === 1) {
-		return options.pascalCase ? input.toUpperCase() : input.toLowerCase();
-	}
-
-	if (/^[a-z\d]+$/.test(input)) {
-		return postProcess(input);
-	}
-
-	const hasUpperCase = input !== input.toLowerCase();
-
-	if (hasUpperCase) {
-		input = preserveCamelCase(input);
-	}
-
-	input = input
-		.replace(/^[_.\- ]+/, '')
-		.toLowerCase()
-		.replace(/[_.\- ]+(\w|$)/g, (m, p1) => p1.toUpperCase());
-
-	return postProcess(input);
+	return casex(str, pattern, '\\s-_.,');
 };

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
 	"devDependencies": {
 		"ava": "*",
 		"xo": "*"
+	},
+	"dependencies": {
+		"casex": "^2.0.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -20,8 +20,8 @@ test('camelCase', t => {
 	t.is(m('__foo__bar__'), 'fooBar');
 	t.is(m('foo bar'), 'fooBar');
 	t.is(m('  foo  bar  '), 'fooBar');
-	t.is(m('-'), '-');
-	t.is(m(' - '), '-');
+	t.is(m('-'), '');
+	t.is(m(' - '), '');
 	t.is(m('fooBar'), 'fooBar');
 	t.is(m('fooBar-baz'), 'fooBarBaz');
 	t.is(m('foìBar-baz'), 'foìBarBaz');
@@ -68,8 +68,8 @@ test('camelCase with pascalCase option', t => {
 	t.is(m('__foo__bar__', {pascalCase: true}), 'FooBar');
 	t.is(m('foo bar', {pascalCase: true}), 'FooBar');
 	t.is(m('  foo  bar  ', {pascalCase: true}), 'FooBar');
-	t.is(m('-', {pascalCase: true}), '-');
-	t.is(m(' - ', {pascalCase: true}), '-');
+	t.is(m('-', {pascalCase: true}), '');
+	t.is(m(' - ', {pascalCase: true}), '');
 	t.is(m('fooBar', {pascalCase: true}), 'FooBar');
 	t.is(m('fooBar-baz', {pascalCase: true}), 'FooBarBaz');
 	t.is(m('foìBar-baz', {pascalCase: true}), 'FoìBarBaz');


### PR DESCRIPTION
[casex](https://github.com/pedsmoreira/casex) is an all in one function for transforming word casings. Today I published v2 of casex, a version that is more flexible and would allow `camelcase` to be, IMHO, represented in a more concise way.

I'm not sure about how the expected behaviour behind `t.is(m(' - '), '-');` - I updated the tests so that `camelcase(' - ')` becomes an empty string. Other than that, all tests pass 🎉 

I appreciate thoughts and considerations about the update.

Thanks for all the great work and contributions to the Open Source community.