### PR TITLE
Improve upper/lower case character detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ const preserveCamelCase = string => {
 			isLastCharUpper = false;
 			isLastCharLower = true;
 		} else {
-			isLastCharLower = character.toLowerCase() === character;
+			isLastCharLower = character.toLowerCase() === character && character.toUpperCase() !== character;
 			isLastLastCharUpper = isLastCharUpper;
-			isLastCharUpper = character.toUpperCase() === character;
+			isLastCharUpper = character.toUpperCase() === character && character.toLowerCase() !== character;
 		}
 	}
 

--- a/test.js
+++ b/test.js
@@ -47,6 +47,8 @@ test('camelCase', t => {
 	t.is(camelCase('AjaxXMLHttpRequest'), 'ajaxXmlHttpRequest');
 	t.is(camelCase('Ajax-XMLHttpRequest'), 'ajaxXmlHttpRequest');
 	t.is(camelCase([]), '');
+	t.is(camelCase('mGridCol6@md'), 'mGridCol6@md');
+	t.is(camelCase('A::a'), 'a::a');
 });
 
 test('camelCase with pascalCase option', t => {
@@ -95,6 +97,8 @@ test('camelCase with pascalCase option', t => {
 	t.is(camelCase('AjaxXMLHttpRequest', {pascalCase: true}), 'AjaxXmlHttpRequest');
 	t.is(camelCase('Ajax-XMLHttpRequest', {pascalCase: true}), 'AjaxXmlHttpRequest');
 	t.is(camelCase([], {pascalCase: true}), '');
+	t.is(camelCase('mGridCol6@md', {pascalCase: true}), 'MGridCol6@md');
+	t.is(camelCase('A::a', {pascalCase: true}), 'A::a');
 });
 
 test('invalid input', t => {


### PR DESCRIPTION
by asserting that a character has an upper and lower case variant, we can be more accurate on determining its case, resolving the issue in #42 

this follows JS convention for asserting case

Adds appropriate test cases

fixes #42 