### PR TITLE
Fix regression with how numbers are treated

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,10 +56,6 @@ const camelCase = (input, options) => {
 		return options.pascalCase ? input.toUpperCase() : input.toLowerCase();
 	}
 
-	if (/^[a-z\d]+$/.test(input)) {
-		return postProcess(input);
-	}
-
 	const hasUpperCase = input !== input.toLowerCase();
 
 	if (hasUpperCase) {
@@ -69,7 +65,8 @@ const camelCase = (input, options) => {
 	input = input
 		.replace(/^[_.\- ]+/, '')
 		.toLowerCase()
-		.replace(/[_.\- ]+(\w|$)/g, (m, p1) => p1.toUpperCase());
+		.replace(/[_.\- ]+(\w|$)/g, (_, p1) => p1.toUpperCase())
+		.replace(/\d+(\w|$)/g, m => m.toUpperCase());
 
 	return postProcess(input);
 };

--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ const preserveCamelCase = string => {
 			isLastCharUpper = false;
 			isLastCharLower = true;
 		} else {
-			isLastCharLower = character.toLowerCase() === character;
+			isLastCharLower = character.toLowerCase() === character && character.toUpperCase() !== character;
 			isLastLastCharUpper = isLastCharUpper;
-			isLastCharUpper = character.toUpperCase() === character;
+			isLastCharUpper = character.toUpperCase() === character && character.toLowerCase() !== character;
 		}
 	}
 

--- a/test.js
+++ b/test.js
@@ -47,6 +47,8 @@ test('camelCase', t => {
 	t.is(camelCase('AjaxXMLHttpRequest'), 'ajaxXmlHttpRequest');
 	t.is(camelCase('Ajax-XMLHttpRequest'), 'ajaxXmlHttpRequest');
 	t.is(camelCase([]), '');
+	t.is(camelCase('mGridCol6@md'), 'mGridCol6@md');
+	t.is(camelCase('A::a'), 'a::a');
 });
 
 test('camelCase with pascalCase option', t => {
@@ -95,6 +97,8 @@ test('camelCase with pascalCase option', t => {
 	t.is(camelCase('AjaxXMLHttpRequest', {pascalCase: true}), 'AjaxXmlHttpRequest');
 	t.is(camelCase('Ajax-XMLHttpRequest', {pascalCase: true}), 'AjaxXmlHttpRequest');
 	t.is(camelCase([], {pascalCase: true}), '');
+	t.is(camelCase('mGridCol6@md', {pascalCase: true}), 'MGridCol6@md');
+	t.is(camelCase('A::a', {pascalCase: true}), 'A::a');
 });
 
 test('invalid input', t => {

--- a/test.js
+++ b/test.js
@@ -49,6 +49,14 @@ test('camelCase', t => {
 	t.is(camelCase([]), '');
 	t.is(camelCase('mGridCol6@md'), 'mGridCol6@md');
 	t.is(camelCase('A::a'), 'a::a');
+	t.is(camelCase('Hello1World'), 'hello1World');
+	t.is(camelCase('Hello11World'), 'hello11World');
+	t.is(camelCase('hello1world'), 'hello1World');
+	t.is(camelCase('Hello1World11foo'), 'hello1World11Foo');
+	t.is(camelCase('Hello1'), 'hello1');
+	t.is(camelCase('hello1'), 'hello1');
+	t.is(camelCase('1Hello'), '1Hello');
+	t.is(camelCase('1hello'), '1Hello');
 });
 
 test('camelCase with pascalCase option', t => {
@@ -99,6 +107,14 @@ test('camelCase with pascalCase option', t => {
 	t.is(camelCase([], {pascalCase: true}), '');
 	t.is(camelCase('mGridCol6@md', {pascalCase: true}), 'MGridCol6@md');
 	t.is(camelCase('A::a', {pascalCase: true}), 'A::a');
+	t.is(camelCase('Hello1World', {pascalCase: true}), 'Hello1World');
+	t.is(camelCase('Hello11World', {pascalCase: true}), 'Hello11World');
+	t.is(camelCase('hello1world', {pascalCase: true}), 'Hello1World');
+	t.is(camelCase('hello1World', {pascalCase: true}), 'Hello1World');
+	t.is(camelCase('hello1', {pascalCase: true}), 'Hello1');
+	t.is(camelCase('Hello1', {pascalCase: true}), 'Hello1');
+	t.is(camelCase('1hello', {pascalCase: true}), '1Hello');
+	t.is(camelCase('1Hello', {pascalCase: true}), '1Hello');
 });
 
 test('invalid input', t => {


### PR DESCRIPTION
previously, preserveCamelCase was treating integers as characters
with case. fix for issue sindresorhus#42 changed that, and characters that don't
have case are no longer considered to be capitalized. This exposed an
issue with integers acting as word breaks, which this commit should
resolve.

- no longer escapes early if lower case characters followed by integers are
found (this was prematurely escaping sequences such as 'aa11aa'). The
escape early is no longer necessary, as the updated regex takes care of
it. If an escape early is still desired for performance on long strings or any other reason, the regex could be altered to ensure it only captures [a-z]+ followed by \d+!
- in the regex, integers are now considered affixed to the word preceding them, and
camel casing resumes after the completion of a series of integers. i.e.
'foo123bar' becomes 'foo123Bar' (before fixes for this issue and sindresorhus#42,
this wasn't occurring, but through the preserveCamelCase behavior and
the early escape mentioned above, we got this behavior)
- tests added!

---

Fixes #52