### PR TITLE
Add test case for integer delimiters

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ const preserveCamelCase = string => {
 			isLastCharUpper = false;
 			isLastCharLower = true;
 		} else {
-			isLastCharLower = character.toLowerCase() === character;
+			isLastCharLower = character.toLowerCase() === character && character.toUpperCase() !== character;
 			isLastLastCharUpper = isLastCharUpper;
-			isLastCharUpper = character.toUpperCase() === character;
+			isLastCharUpper = character.toUpperCase() === character && character.toLowerCase() !== character;
 		}
 	}
 

--- a/test.js
+++ b/test.js
@@ -57,6 +57,7 @@ test('camelCase', t => {
 	t.is(camelCase('hello1'), 'hello1');
 	t.is(camelCase('1Hello'), '1Hello');
 	t.is(camelCase('1hello'), '1Hello');
+	t.is(camelCase('h2w'), 'h2W');
 });
 
 test('camelCase with pascalCase option', t => {
@@ -115,6 +116,7 @@ test('camelCase with pascalCase option', t => {
 	t.is(camelCase('Hello1', {pascalCase: true}), 'Hello1');
 	t.is(camelCase('1hello', {pascalCase: true}), '1Hello');
 	t.is(camelCase('1Hello', {pascalCase: true}), '1Hello');
+	t.is(camelCase('h1W', {pascalCase: true}), 'H1W');
 });
 
 test('invalid input', t => {

--- a/test.js
+++ b/test.js
@@ -47,6 +47,8 @@ test('camelCase', t => {
 	t.is(camelCase('AjaxXMLHttpRequest'), 'ajaxXmlHttpRequest');
 	t.is(camelCase('Ajax-XMLHttpRequest'), 'ajaxXmlHttpRequest');
 	t.is(camelCase([]), '');
+	t.is(camelCase('mGridCol6@md'), 'mGridCol6@md');
+	t.is(camelCase('A::a'), 'a::a');
 });
 
 test('camelCase with pascalCase option', t => {
@@ -95,6 +97,8 @@ test('camelCase with pascalCase option', t => {
 	t.is(camelCase('AjaxXMLHttpRequest', {pascalCase: true}), 'AjaxXmlHttpRequest');
 	t.is(camelCase('Ajax-XMLHttpRequest', {pascalCase: true}), 'AjaxXmlHttpRequest');
 	t.is(camelCase([], {pascalCase: true}), '');
+	t.is(camelCase('mGridCol6@md', {pascalCase: true}), 'MGridCol6@md');
+	t.is(camelCase('A::a', {pascalCase: true}), 'A::a');
 });
 
 test('invalid input', t => {


### PR DESCRIPTION
this adds a single test case to cover the discussion in #54 
[the discussion pointed out that there was no test case for a single character following an integer](https://github.com/sindresorhus/camelcase/issues/54#issuecomment-481551896)

certainly not a priority to get this in
