### PR TITLE
Fix broken Travis badge link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# camelcase [![Build Status](https://travis-ci.org/sindresorhus/camelcase.svg?branch=master)](https://travis-ci.org/sindresorhus/camelcase)
+# camelcase [![Build Status](https://travis-ci.org/sindresorhus/camelcase.svg?branch=master)](https://travis-ci.com/sindresorhus/camelcase)
 
 > Convert a dash/dot/underscore/space separated string to camelCase or PascalCase: `foo-bar` → `fooBar`
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# camelcase [![Build Status](https://travis-ci.org/sindresorhus/camelcase.svg?branch=master)](https://travis-ci.com/sindresorhus/camelcase)
+# camelcase [![Build Status](https://travis-ci.com/sindresorhus/camelcase.svg?branch=master)](https://travis-ci.com/sindresorhus/camelcase)
 
 > Convert a dash/dot/underscore/space separated string to camelCase or PascalCase: `foo-bar` → `fooBar`
 


### PR DESCRIPTION
Looks like travis has moved from .org to .com