### PR TITLE
Add `preserveConsecutiveUppercase` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare namespace camelcase {
 		@example
 		```
 		import camelCase = require('camelcase');
+
 		camelCase('lorem-ipsum', {locale: 'en-US'});
 		//=> 'loremIpsum'
 		camelCase('lorem-ipsum', {locale: 'tr-TR'});

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ camelCase('--foo.bar', {pascalCase: false});
 //=> 'fooBar'
 
 camelCase('Foo-Bar', {preserveConsecutiveUppercase: true});
-//=> 'FooBAR'
+//=> 'fooBAR'
 
 camelCase('fooBaR', {pascalCase: true, preserveConsecutiveUppercase: true}));
 //=> 'FooBaR'

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ camelCase('Foo-Bar', {pascalCase: true});
 camelCase('--foo.bar', {pascalCase: false});
 //=> 'fooBar'
 
-camelCase('Foo-Bar', {preserveConsecutiveUppercase: true});
+camelCase('Foo-BAR', {preserveConsecutiveUppercase: true});
 //=> 'fooBAR'
 
 camelCase('fooBAR', {pascalCase: true, preserveConsecutiveUppercase: true}));

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,13 @@ declare namespace camelcase {
 		@default false
 		*/
 		readonly pascalCase?: boolean;
+
+		/**
+		Preserve the consecutive uppercase characters: `foo-BAR` → `FooBAR`.
+
+		@default false
+		*/
+		readonly preserveConsecutiveUppercase?: boolean;
 	}
 }
 
@@ -18,7 +25,7 @@ Correctly handles Unicode strings.
 
 @example
 ```
-import camelCase = require('camelcase');
+const camelCase = require('camelcase');
 
 camelCase('foo-bar');
 //=> 'fooBar'
@@ -38,6 +45,12 @@ camelCase('Foo-Bar', {pascalCase: true});
 camelCase('--foo.bar', {pascalCase: false});
 //=> 'fooBar'
 
+camelCase('Foo-Bar', {preserveConsecutiveUppercase: true});
+//=> 'FooBAR'
+
+camelCase('fooBaR', {pascalCase: true, preserveConsecutiveUppercase: true}));
+//=> 'FooBaR'
+
 camelCase('foo bar');
 //=> 'fooBar'
 
@@ -51,6 +64,9 @@ camelCase(['foo', 'bar']);
 
 camelCase(['__foo__', '--bar'], {pascalCase: true});
 //=> 'FooBar'
+
+camelCase(['foo', 'BAR'], {pascalCase: true, preserveConsecutiveUppercase: true})
+//=> 'FooBAR'
 ```
 */
 declare function camelcase(

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,9 @@ declare namespace camelcase {
 
 		/**
 		The locale parameter indicates the locale to be used to convert to upper/lower case according to any locale-specific case mappings. If multiple locales are given in an array, the best available locale is used.
+
 		Default: The host environment’s current locale.
+
 		@example
 		```
 		import camelCase = require('camelcase');

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ Correctly handles Unicode strings.
 
 @example
 ```
-const camelCase = require('camelcase');
+import camelCase = require('camelcase');
 
 camelCase('foo-bar');
 //=> 'fooBar'
@@ -48,8 +48,8 @@ camelCase('--foo.bar', {pascalCase: false});
 camelCase('Foo-Bar', {preserveConsecutiveUppercase: true});
 //=> 'fooBAR'
 
-camelCase('fooBaR', {pascalCase: true, preserveConsecutiveUppercase: true}));
-//=> 'FooBaR'
+camelCase('fooBAR', {pascalCase: true, preserveConsecutiveUppercase: true}));
+//=> 'FooBAR'
 
 camelCase('foo bar');
 //=> 'fooBar'

--- a/index.js
+++ b/index.js
@@ -29,17 +29,25 @@ const preserveCamelCase = string => {
 	return string;
 };
 
+const preserveConsecutiveUppercase = input => {
+	return input.replace(/^[\p{Lu}](?![\p{Lu}])/gu, m1 => m1.toLowerCase());
+};
+
+const postProcess = input => {
+	return input.replace(/[_.\- ]+([\p{Alpha}\p{N}_]|$)/gu, (_, p1) => p1.toLocaleUpperCase())
+		.replace(/\d+([\p{Alpha}\p{N}_]|$)/gu, m => m.toLocaleUpperCase());
+};
+
 const camelCase = (input, options) => {
 	if (!(typeof input === 'string' || Array.isArray(input))) {
 		throw new TypeError('Expected the input to be `string | string[]`');
 	}
 
 	options = {
-		...{pascalCase: false},
+		pascalCase: false,
+		preserveConsecutiveUppercase: false,
 		...options
 	};
-
-	const postProcess = x => options.pascalCase ? x.charAt(0).toLocaleUpperCase() + x.slice(1) : x;
 
 	if (Array.isArray(input)) {
 		input = input.map(x => x.trim())
@@ -63,11 +71,17 @@ const camelCase = (input, options) => {
 		input = preserveCamelCase(input);
 	}
 
-	input = input
-		.replace(/^[_.\- ]+/, '')
-		.toLocaleLowerCase()
-		.replace(/[_.\- ]+([\p{Alpha}\p{N}_]|$)/gu, (_, p1) => p1.toLocaleUpperCase())
-		.replace(/\d+([\p{Alpha}\p{N}_]|$)/gu, m => m.toLocaleUpperCase());
+	input = input.replace(/^[_.\- ]+/, '');
+
+	if (options.preserveConsecutiveUppercase) {
+		input = preserveConsecutiveUppercase(input);
+	} else {
+		input = input.toLocaleLowerCase();
+	}
+
+	if (options.pascalCase) {
+		input = input.charAt(0).toLocaleUpperCase() + input.slice(1);
+	}
 
 	return postProcess(input);
 };

--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,8 @@ camelCase('--foo.bar', {pascalCase: false});
 camelCase('Foo-Bar', {preserveConsecutiveUppercase: true});
 //=> 'fooBAR'
 
-camelCase('fooBaR', {pascalCase: true, preserveConsecutiveUppercase: true}));
-//=> 'FooBaR'
+camelCase('fooBAR', {pascalCase: true, preserveConsecutiveUppercase: true}));
+//=> 'FooBAR'
 
 camelCase('foo bar');
 //=> 'fooBar'

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ camelCase('Foo-Bar', {pascalCase: true});
 camelCase('--foo.bar', {pascalCase: false});
 //=> 'fooBar'
 
-camelCase('Foo-Bar', {preserveConsecutiveUppercase: true});
+camelCase('Foo-BAR', {preserveConsecutiveUppercase: true});
 //=> 'fooBAR'
 
 camelCase('fooBAR', {pascalCase: true, preserveConsecutiveUppercase: true}));

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# camelcase [![Build Status](https://travis-ci.org/sindresorhus/camelcase.svg?branch=master)](https://travis-ci.org/sindresorhus/camelcase)
+# camelcase [![Build Status](https://travis-ci.com/sindresorhus/camelcase.svg?branch=master)](https://travis-ci.com/sindresorhus/camelcase)
 
 > Convert a dash/dot/underscore/space separated string to camelCase or PascalCase: `foo-bar` → `fooBar`
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ camelCase('--foo.bar', {pascalCase: false});
 //=> 'fooBar'
 
 camelCase('Foo-Bar', {preserveConsecutiveUppercase: true});
-//=> 'FooBAR'
+//=> 'fooBAR'
 
 camelCase('fooBaR', {pascalCase: true, preserveConsecutiveUppercase: true}));
 //=> 'FooBaR'

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,12 @@ camelCase('Foo-Bar', {pascalCase: true});
 camelCase('--foo.bar', {pascalCase: false});
 //=> 'fooBar'
 
+camelCase('Foo-Bar', {preserveConsecutiveUppercase: true});
+//=> 'FooBAR'
+
+camelCase('fooBaR', {pascalCase: true, preserveConsecutiveUppercase: true}));
+//=> 'FooBaR'
+
 camelCase('foo bar');
 //=> 'fooBar'
 
@@ -48,6 +54,9 @@ camelCase(['foo', 'bar']);
 
 camelCase(['__foo__', '--bar'], {pascalCase: true});
 //=> 'FooBar'
+
+camelCase(['foo', 'BAR'], {pascalCase: true, preserveConsecutiveUppercase: true})
+//=> 'FooBAR'
 ```
 
 ## API
@@ -70,6 +79,13 @@ Type: `boolean`\
 Default: `false`
 
 Uppercase the first character: `foo-bar` → `FooBar`
+
+##### preserveConsecutiveUppercase
+
+Type: `boolean`\
+Default: `false`
+
+Preserve the consecutive uppercase characters: `foo-BAR` → `FooBAR`
 
 ## camelcase for enterprise
 

--- a/test.js
+++ b/test.js
@@ -132,6 +132,7 @@ test('camelCase with pascalCase option', t => {
 
 test('camelCase with preserveConsecutiveUppercase option', t => {
 	t.is(camelCase('foo-BAR', {preserveConsecutiveUppercase: true}), 'fooBAR');
+	t.is(camelCase('Foo-BAR', {preserveConsecutiveUppercase: true}), 'fooBAR');
 	t.is(camelCase('fooBAR', {preserveConsecutiveUppercase: true}), 'fooBAR');
 	t.is(camelCase('fooBaR', {preserveConsecutiveUppercase: true}), 'fooBaR');
 	t.is(camelCase('FOÈ-BAR', {preserveConsecutiveUppercase: true}), 'FOÈBAR');

--- a/test.js
+++ b/test.js
@@ -130,6 +130,67 @@ test('camelCase with pascalCase option', t => {
 	t.is(camelCase('桑德_在这里。', {pascalCase: true}), '桑德在这里。');
 });
 
+test('camelCase with preserveConsecutiveUppercase option', t => {
+	t.is(camelCase('foo-BAR', {preserveConsecutiveUppercase: true}), 'fooBAR');
+	t.is(camelCase('fooBAR', {preserveConsecutiveUppercase: true}), 'fooBAR');
+	t.is(camelCase('fooBaR', {preserveConsecutiveUppercase: true}), 'fooBaR');
+	t.is(camelCase('FOÈ-BAR', {preserveConsecutiveUppercase: true}), 'FOÈBAR');
+	t.is(camelCase(['foo', 'BAR'], {preserveConsecutiveUppercase: true}), 'fooBAR');
+	t.is(camelCase(['foo', '-BAR'], {preserveConsecutiveUppercase: true}), 'fooBAR');
+	t.is(camelCase(['foo', '-BAR', 'baz'], {preserveConsecutiveUppercase: true}), 'fooBARBaz');
+	t.is(camelCase(['', ''], {preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('--', {preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('', {preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('--__--_--_', {preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase(['---_', '--', '', '-_- '], {preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('foo BAR?', {preserveConsecutiveUppercase: true}), 'fooBAR?');
+	t.is(camelCase('foo BAR!', {preserveConsecutiveUppercase: true}), 'fooBAR!');
+	t.is(camelCase('foo BAR$', {preserveConsecutiveUppercase: true}), 'fooBAR$');
+	t.is(camelCase('foo-BAR#', {preserveConsecutiveUppercase: true}), 'fooBAR#');
+	t.is(camelCase('XMLHttpRequest', {preserveConsecutiveUppercase: true}), 'XMLHttpRequest');
+	t.is(camelCase('AjaxXMLHttpRequest', {preserveConsecutiveUppercase: true}), 'ajaxXMLHttpRequest');
+	t.is(camelCase('Ajax-XMLHttpRequest', {preserveConsecutiveUppercase: true}), 'ajaxXMLHttpRequest');
+	t.is(camelCase([], {preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('mGridCOl6@md', {preserveConsecutiveUppercase: true}), 'mGridCOl6@md');
+	t.is(camelCase('A::a', {preserveConsecutiveUppercase: true}), 'a::a');
+	t.is(camelCase('Hello1WORLD', {preserveConsecutiveUppercase: true}), 'hello1WORLD');
+	t.is(camelCase('Hello11WORLD', {preserveConsecutiveUppercase: true}), 'hello11WORLD');
+	t.is(camelCase('РозовыйПушистыйFOOдинорогиf', {preserveConsecutiveUppercase: true}), 'розовыйПушистыйFOOдинорогиf');
+	t.is(camelCase('桑德在这里。', {preserveConsecutiveUppercase: true}), '桑德在这里。');
+	t.is(camelCase('桑德_在这里。', {preserveConsecutiveUppercase: true}), '桑德在这里。');
+});
+
+test('camelCase with both -pascalCase and -preserveConsecutiveUppercase option', t => {
+	t.is(camelCase('foo-BAR', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR');
+	t.is(camelCase('fooBAR', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR');
+	t.is(camelCase('fooBaR', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBaR');
+	t.is(camelCase('fOÈ-BAR', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FOÈBAR');
+	t.is(camelCase('--foo.BAR', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR');
+	t.is(camelCase(['Foo', 'BAR'], {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR');
+	t.is(camelCase(['foo', '-BAR'], {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR');
+	t.is(camelCase(['foo', '-BAR', 'baz'], {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBARBaz');
+	t.is(camelCase(['', ''], {pascalCase: true, preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('--', {pascalCase: true, preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('', {pascalCase: true, preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('--__--_--_', {pascalCase: true, preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase(['---_', '--', '', '-_- '], {pascalCase: true, preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('foo BAR?', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR?');
+	t.is(camelCase('foo BAR!', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR!');
+	t.is(camelCase('Foo BAR$', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR$');
+	t.is(camelCase('foo-BAR#', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR#');
+	t.is(camelCase('xMLHttpRequest', {pascalCase: true, preserveConsecutiveUppercase: true}), 'XMLHttpRequest');
+	t.is(camelCase('ajaxXMLHttpRequest', {pascalCase: true, preserveConsecutiveUppercase: true}), 'AjaxXMLHttpRequest');
+	t.is(camelCase('Ajax-XMLHttpRequest', {pascalCase: true, preserveConsecutiveUppercase: true}), 'AjaxXMLHttpRequest');
+	t.is(camelCase([], {pascalCase: true, preserveConsecutiveUppercase: true}), '');
+	t.is(camelCase('mGridCOl6@md', {pascalCase: true, preserveConsecutiveUppercase: true}), 'MGridCOl6@md');
+	t.is(camelCase('A::a', {pascalCase: true, preserveConsecutiveUppercase: true}), 'A::a');
+	t.is(camelCase('Hello1WORLD', {pascalCase: true, preserveConsecutiveUppercase: true}), 'Hello1WORLD');
+	t.is(camelCase('Hello11WORLD', {pascalCase: true, preserveConsecutiveUppercase: true}), 'Hello11WORLD');
+	t.is(camelCase('pозовыйПушистыйFOOдинорогиf', {pascalCase: true, preserveConsecutiveUppercase: true}), 'PозовыйПушистыйFOOдинорогиf');
+	t.is(camelCase('桑德在这里。', {pascalCase: true, preserveConsecutiveUppercase: true}), '桑德在这里。');
+	t.is(camelCase('桑德_在这里。', {pascalCase: true, preserveConsecutiveUppercase: true}), '桑德在这里。');
+});
+
 test('invalid input', t => {
 	t.throws(() => {
 		camelCase(1);

--- a/test.js
+++ b/test.js
@@ -161,7 +161,7 @@ test('camelCase with preserveConsecutiveUppercase option', t => {
 	t.is(camelCase('桑德_在这里。', {preserveConsecutiveUppercase: true}), '桑德在这里。');
 });
 
-test('camelCase with both -pascalCase and -preserveConsecutiveUppercase option', t => {
+test('camelCase with both pascalCase and preserveConsecutiveUppercase option', t => {
 	t.is(camelCase('foo-BAR', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR');
 	t.is(camelCase('fooBAR', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBAR');
 	t.is(camelCase('fooBaR', {pascalCase: true, preserveConsecutiveUppercase: true}), 'FooBaR');


### PR DESCRIPTION
fixes #76 
Builds on the reviews left on the previous attempt #64 

- [x]  Added test cases
- [x] Updated `README`
- [x]  Synced the updated examples of readme with declaration file
- [x] Made some additional _irrelevant_ to the issue tweaks [like removing spread operators from a single property ]

This to 
```js
options = {
       ...{pascalCase: false},
       ...options
};
```
to
```js
options = {
       pascalCase: false,
       ...options
};
```

// @sindresorhus 