### PR TITLE
Document Firefox version incompatibility (<78)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Correctly handles Unicode strings.
 $ npm install camelcase
 ```
 
-*If you need to support Firefox, stay on version 5 as version 6 uses regex features not available in Firefox.*
+*If you need to support Firefox < 78, stay on version 5 as version 6 uses regex features not available in Firefox < 78.*
 
 ## Usage
 


### PR DESCRIPTION
Firefox 78 added the needed support for the required regex features, to my knowledge.

See https://hacks.mozilla.org/2020/06/new-in-firefox-78/

I have updated the disclaimer to hopefully help others.
Thanks for the library @sindresorhus 
