### PR TITLE
Add target option

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,11 +45,16 @@ const preserveConsecutiveUppercase = (input, toLowerCase) => {
 	return input.replace(LEADING_CAPITAL, m1 => toLowerCase(m1));
 };
 
-const postProcess = (input, toUpperCase) => {
-	SEPARATORS_AND_IDENTIFIER.lastIndex = 0;
+const postProcess = (input, toUpperCase, convertTarget) => {
+	let separatorsAndIdentifier = SEPARATORS_AND_IDENTIFIER;
+	if (convertTarget) {
+		separatorsAndIdentifier = new RegExp(convertTarget + IDENTIFIER.source, 'gu');
+	}
+
+	separatorsAndIdentifier.lastIndex = 0;
 	NUMBERS_AND_IDENTIFIER.lastIndex = 0;
 
-	return input.replace(SEPARATORS_AND_IDENTIFIER, (_, identifier) => toUpperCase(identifier))
+	return input.replace(separatorsAndIdentifier, (_, identifier) => toUpperCase(identifier))
 		.replace(NUMBERS_AND_IDENTIFIER, m => toUpperCase(m));
 };
 
@@ -93,7 +98,37 @@ const camelCase = (input, options) => {
 		input = preserveCamelCase(input, toLowerCase, toUpperCase);
 	}
 
-	input = input.replace(LEADING_SEPARATORS, '');
+	let leadingSeparators = LEADING_SEPARATORS;
+
+	let convertTarget = '';
+	if (options.target) {
+		const {target} = options;
+		convertTarget = '[';
+		if (target.includes('-')) {
+			convertTarget += '-';
+		}
+
+		if (target.includes('_')) {
+			convertTarget += '_';
+		}
+
+		if (target.includes('.')) {
+			convertTarget += '.';
+		}
+
+		if (target.includes('/')) {
+			convertTarget += '//';
+		}
+
+		if (target.includes(' ')) {
+			convertTarget += ' ';
+		}
+
+		convertTarget += ']+';
+		leadingSeparators = new RegExp('^' + convertTarget);
+	}
+
+	input = input.replace(leadingSeparators, '');
 
 	if (options.preserveConsecutiveUppercase) {
 		input = preserveConsecutiveUppercase(input, toLowerCase);
@@ -105,7 +140,7 @@ const camelCase = (input, options) => {
 		input = toUpperCase(input.charAt(0)) + input.slice(1);
 	}
 
-	return postProcess(input, toUpperCase);
+	return postProcess(input, toUpperCase, convertTarget);
 };
 
 module.exports = camelCase;

--- a/index.js
+++ b/index.js
@@ -45,10 +45,10 @@ const preserveConsecutiveUppercase = (input, toLowerCase) => {
 	return input.replace(LEADING_CAPITAL, m1 => toLowerCase(m1));
 };
 
-const postProcess = (input, toUpperCase, convertTarget) => {
+const postProcess = (input, toUpperCase, regString) => {
 	let separatorsAndIdentifier = SEPARATORS_AND_IDENTIFIER;
-	if (convertTarget) {
-		separatorsAndIdentifier = new RegExp(convertTarget + IDENTIFIER.source, 'gu');
+	if (regString) {
+		separatorsAndIdentifier = new RegExp(regString + IDENTIFIER.source, 'gu');
 	}
 
 	separatorsAndIdentifier.lastIndex = 0;
@@ -100,32 +100,28 @@ const camelCase = (input, options) => {
 
 	let leadingSeparators = LEADING_SEPARATORS;
 
-	let convertTarget = '';
-	if (options.target) {
-		const {target} = options;
-		convertTarget = '[';
-		if (target.includes('-')) {
-			convertTarget += '-';
+	let regString = '';
+	if (options.preserveCharacters) {
+		const {preserveCharacters} = options;
+		regString = '[';
+		if (!preserveCharacters.includes('-')) {
+			regString += '-';
 		}
 
-		if (target.includes('_')) {
-			convertTarget += '_';
+		if (!preserveCharacters.includes('_')) {
+			regString += '_';
 		}
 
-		if (target.includes('.')) {
-			convertTarget += '.';
+		if (!preserveCharacters.includes('.')) {
+			regString += '.';
 		}
 
-		if (target.includes('/')) {
-			convertTarget += '//';
+		if (!preserveCharacters.includes(' ')) {
+			regString += ' ';
 		}
 
-		if (target.includes(' ')) {
-			convertTarget += ' ';
-		}
-
-		convertTarget += ']+';
-		leadingSeparators = new RegExp('^' + convertTarget);
+		regString += ']+';
+		leadingSeparators = new RegExp('^' + regString);
 	}
 
 	input = input.replace(leadingSeparators, '');
@@ -140,7 +136,7 @@ const camelCase = (input, options) => {
 		input = toUpperCase(input.charAt(0)) + input.slice(1);
 	}
 
-	return postProcess(input, toUpperCase, convertTarget);
+	return postProcess(input, toUpperCase, regString);
 };
 
 module.exports = camelCase;

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,13 @@ Default: `false`
 
 Preserve the consecutive uppercase characters: `foo-BAR` → `FooBAR`.
 
+##### target
+
+Type: `string`\
+Default: `_.\- `
+
+Determine the target characters for conversion: `foo_bar.1` → `fooBar.1`.
+
 ##### locale
 
 Type: `false | string | string[]`\

--- a/readme.md
+++ b/readme.md
@@ -92,12 +92,20 @@ Default: `false`
 
 Preserve the consecutive uppercase characters: `foo-BAR` → `FooBAR`.
 
-##### target
+##### preserveCharacters
 
-Type: `string`\
-Default: `_.\- `
+Type: `string[]`\
 
-Determine the target characters for conversion: `foo_bar.1` → `fooBar.1`.
+Preserve the given characters. The characters that can be specified are '_', '.', '-', ' ' or a combination thereof.
+```js
+const camelCase = require('camelcase');
+
+camelCase('foo_bar.1', {preserveCharacters: ['.']});
+//=> 'fooBar.1'
+
+camelCase('foo_bar.1-1', {preserveCharacters: ['.', '-']);
+//=> 'fooBar.1-1'
+```
 
 ##### locale
 

--- a/test.js
+++ b/test.js
@@ -194,11 +194,16 @@ test('camelCase with both pascalCase and preserveConsecutiveUppercase option', t
 	t.is(camelCase('桑德_在这里。', {pascalCase: true, preserveConsecutiveUppercase: true}), '桑德在这里。');
 });
 
-test('camelCase with target option', t => {
-	t.is(camelCase('foo_bar.1', {target: '_\\- '}), 'fooBar.1');
-	t.is(camelCase('foo_bar-1', {target: '_.\\ '}), 'fooBar-1');
-	t.is(camelCase('foo_bar/1', {target: '_.- '}), 'fooBar/1');
-	t.is(camelCase('foo_bar 1', {target: '_.\\-'}), 'fooBar 1');
+test('camelCase with preserveCharacters option', t => {
+	t.is(camelCase('foo_bar.1', {preserveCharacters: ['.']}), 'fooBar.1');
+	t.is(camelCase('foo_bar-1', {preserveCharacters: ['-']}), 'fooBar-1');
+	t.is(camelCase('foo_bar 1', {preserveCharacters: [' ']}), 'fooBar 1');
+	t.is(camelCase('foo.bar_1', {preserveCharacters: ['_']}), 'fooBar_1');
+	t.is(camelCase('foo_bar.1-1', {preserveCharacters: ['.', '-']}), 'fooBar.1-1');
+	t.is(camelCase('abc_def.ghi-jkl mno', {preserveCharacters: ['_']}), 'abc_defGhiJklMno');
+	t.is(camelCase('abc_def.ghi-jkl mno', {preserveCharacters: ['_', '.', '-', ' ']}), 'abc_def.ghi-jkl mno');
+	t.is(camelCase('foo_BAR.1', {pascalCase: true, preserveCharacters: ['.']}), 'FooBar.1');
+	t.is(camelCase('foo_BAR.1', {preserveConsecutiveUppercase: true, preserveCharacters: ['.']}), 'fooBAR.1');
 });
 
 test('camelCase with locale option', t => {
@@ -217,6 +222,7 @@ test('camelCase with disabled locale', t => {
 		t.is(camelCase('lorem-ipsum', {locale: false}), 'loremIpsum');
 		t.is(camelCase('ipsum-dolor', {pascalCase: true, locale: false}), 'IpsumDolor');
 		t.is(camelCase('ipsum-DOLOR', {pascalCase: true, locale: false, preserveConsecutiveUppercase: true}), 'IpsumDOLOR');
+		t.is(camelCase('lorem-ipsum.1', {pascalCase: true, locale: false, preserveConsecutiveUppercase: true, preserveCharacters: ['.']}), 'LoremIpsum.1');
 	});
 });
 

--- a/test.js
+++ b/test.js
@@ -64,6 +64,7 @@ test('camelCase', t => {
 	t.is(camelCase('桑德在这里。'), '桑德在这里。');
 	t.is(camelCase('桑德在这里。'), '桑德在这里。');
 	t.is(camelCase('桑德_在这里。'), '桑德在这里。');
+	t.is(camelCase('foo_bar.1'), 'fooBar1');
 });
 
 test('camelCase with pascalCase option', t => {
@@ -191,6 +192,13 @@ test('camelCase with both pascalCase and preserveConsecutiveUppercase option', t
 	t.is(camelCase('pозовыйПушистыйFOOдинорогиf', {pascalCase: true, preserveConsecutiveUppercase: true}), 'PозовыйПушистыйFOOдинорогиf');
 	t.is(camelCase('桑德在这里。', {pascalCase: true, preserveConsecutiveUppercase: true}), '桑德在这里。');
 	t.is(camelCase('桑德_在这里。', {pascalCase: true, preserveConsecutiveUppercase: true}), '桑德在这里。');
+});
+
+test('camelCase with target option', t => {
+	t.is(camelCase('foo_bar.1', {target: '_\\- '}), 'fooBar.1');
+	t.is(camelCase('foo_bar-1', {target: '_.\\ '}), 'fooBar-1');
+	t.is(camelCase('foo_bar/1', {target: '_.- '}), 'fooBar/1');
+	t.is(camelCase('foo_bar 1', {target: '_.\\-'}), 'fooBar 1');
 });
 
 test('camelCase with locale option', t => {


### PR DESCRIPTION
I wanted to convert it to:
`camelCase(foo_bar.1)` => `fooBar.1`

At present, it will be converted to `fooBar1`.
That's why I implemented the target option.