### PR TITLE
refactor: use string constants for identifiers and separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 const UPPERCASE = /[\p{Lu}]/u;
 const LOWERCASE = /[\p{Ll}]/u;
 const LEADING_CAPITAL = /^[\p{Lu}](?![\p{Lu}])/gu;
-const IDENTIFIER = /([\p{Alpha}\p{N}_]|$)/u;
-const SEPARATORS = /[_.\- ]+/;
+const IDENTIFIER = '([\\p{Alpha}\\p{N}_]|$)'; // Must be used with 'u' flag
+const SEPARATORS = '[_.\\- ]+';
 
-const LEADING_SEPARATORS = new RegExp('^' + SEPARATORS.source);
-const SEPARATORS_AND_IDENTIFIER = new RegExp(SEPARATORS.source + IDENTIFIER.source, 'gu');
-const NUMBERS_AND_IDENTIFIER = new RegExp('\\d+' + IDENTIFIER.source, 'gu');
+const LEADING_SEPARATORS = new RegExp('^' + SEPARATORS);
+const SEPARATORS_AND_IDENTIFIER = new RegExp(SEPARATORS + IDENTIFIER, 'gu');
+const NUMBERS_AND_IDENTIFIER = new RegExp('\\d+' + IDENTIFIER, 'gu');
 
 const preserveCamelCase = (string, toLowerCase, toUpperCase) => {
 	let isLastCharLower = false;


### PR DESCRIPTION
This will make it possible to statically evaluate its usage therefore allowing to transpile regexes to ES5 compatible ones on compile e.g. via `babel-plugin-transform-unicode-regexp-runtime`.