### PR TITLE
Add failing idempotence test

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"pascal-case"
 	],
 	"devDependencies": {
+		"@fast-check/ava": "^2.0.2",
 		"ava": "^5.3.1",
 		"tsd": "^0.28.1",
 		"xo": "^0.55.1"

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import {fc, testProp} from '@fast-check/ava';
 import camelCase from './index.js';
 
 test('camelCase', t => {
@@ -234,6 +235,21 @@ test('invalid input', t => {
 	}, {
 		message: /Expected the input to be/,
 	});
+});
+
+const localeArb = fc.constantFrom('tr-TR', 'en-EN', 'en-GB');
+testProp.failing('camelCase idempotence', [
+	fc.string(),
+	fc.record({
+		locale: fc.oneof(fc.boolean(), localeArb, fc.uniqueArray(localeArb)),
+		pascalCase: fc.boolean(),
+		preserveConsecutiveUppercase: fc.boolean(),
+	}),
+], (t, string, options) => {
+	const camelCased = camelCase(string, options);
+	const doubleCamelCased = camelCase(camelCased, options);
+
+	t.is(doubleCamelCased, camelCased);
 });
 
 /* eslint-disable no-extend-native */


### PR DESCRIPTION
I noticed that `camelCase` is not idempotent, which I think is a bug. i.e. if `camelCase` is meant to return a camel-cased version of the input, then camel-casing it _again_ should not result in a diff because it's already been camel-cased.

I've added a failing property-based test for this, but haven't figured out what the implementation bug is exactly. Feel free to merge as-is, but I may update this PR with an actual bug fix if I have time.

An example of a case that fails is `"{ A"`:
- `camelCase("{ A") -> "{A"`
- `camelCase(camelCase("{ A")) -> "{a"`